### PR TITLE
Add travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+install: true
+script: ant run-tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 The Polymer Renamer
 ===================
+
+[!Travis Build Status](https://travis-ci.org/PolymerLabs/PolymerRenamer.svg?branch=master)
+
 The Polymer Renamer helps developers integrate the Google Closure compiler with
 their Polymer projects by forwarding renames performed by the compiler to HTML
 and JS files.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 The Polymer Renamer
 ===================
 
-[!Travis Build Status](https://travis-ci.org/PolymerLabs/PolymerRenamer.svg?branch=master)
+[![Build Status](https://travis-ci.org/PolymerLabs/PolymerRenamer.svg?branch=master)](https://travis-ci.org/PolymerLabs/PolymerRenamer)
 
 The Polymer Renamer helps developers integrate the Google Closure compiler with
 their Polymer projects by forwarding renames performed by the compiler to HTML


### PR DESCRIPTION
I'd like to add npm/grunt/gulp integrations and have PRs auto-run any tests. The first step in this is to enable travis-ci testing for the existing unit tests.
